### PR TITLE
Add stricter Ruff linting

### DIFF
--- a/dissect/thumbcache/__init__.py
+++ b/dissect/thumbcache/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.thumbcache.exceptions import Error
 from dissect.thumbcache.index import IndexEntry, ThumbnailIndex
 from dissect.thumbcache.thumbcache import Thumbcache

--- a/dissect/thumbcache/exceptions.py
+++ b/dissect/thumbcache/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Error(Exception):
     """A generic exception for the thumbcache module."""
 

--- a/dissect/thumbcache/thumbcache.py
+++ b/dissect/thumbcache/thumbcache.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from dissect.thumbcache.index import IndexEntry, ThumbnailIndex
-from dissect.thumbcache.thumbcache_file import ThumbcacheEntry, ThumbcacheFile
+from dissect.thumbcache.index import ThumbnailIndex
+from dissect.thumbcache.thumbcache_file import ThumbcacheFile
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
+
+    from dissect.thumbcache.index import IndexEntry
+    from dissect.thumbcache.thumbcache_file import ThumbcacheEntry
 
 
 class Thumbcache:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ select = [
   "SLOT",
   "SIM",
   "TID",
-  "TCH",
+  "TC",
   "PTH",
   "PLC",
   "TRY",
@@ -106,8 +106,25 @@ select = [
   "PERF",
   "FURB",
   "RUF",
+  "D"
 ]
-ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003"]
+ignore = [
+    "E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003", "PLC0415",
+    # Ignore some pydocstyle rules for now as they require a larger cleanup
+    "D1",
+    "D205",
+    "D301",
+    "D417",
+    # Seems bugged: https://github.com/astral-sh/ruff/issues/16824
+    "D402",
+]
+future-annotations = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/_docs/**" = ["INP001"]
@@ -115,6 +132,7 @@ ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM1
 [tool.ruff.lint.isort]
 known-first-party = ["dissect.thumbcache"]
 known-third-party = ["dissect"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.setuptools.packages.find]
 include = ["dissect.*"]

--- a/tests/_docs/conf.py
+++ b/tests/_docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 extensions = [
     "autoapi.extension",
     "sphinx.ext.autodoc",


### PR DESCRIPTION
Add docstyle rules + rename rule TCH to TC + enforce future-annotations

Mainly changes related and from __future__ import annotations added.

Commit will be added to .git-blame-ignore-revs

* fixes #25 